### PR TITLE
fix: fixing incorrect prop verticalAlignment to verticalAlign

### DIFF
--- a/store/blocks/product/assembly-options.jsonc
+++ b/store/blocks/product/assembly-options.jsonc
@@ -53,7 +53,7 @@
   "flex-layout.col#product-assembly-middle": {
     "props": {
       "width": "grow",
-      "verticalAlignment": "middle"
+      "verticalAlign": "middle"
     },
     "children": [
       "assembly-option-item-name",
@@ -91,7 +91,7 @@
   "flex-layout.col#item-customize-middle": {
     "props": {
       "width": "grow",
-      "verticalAlignment": "middle"
+      "verticalAlign": "middle"
     },
     "children": [
       "assembly-option-item-name",


### PR DESCRIPTION
#### What problem is this solving?
This fixes incorrect prop verticalAlignment to verticalAlign on store/product/assembly-option.jsonc

<!--- What is the motivation and context for this change? -->
The prop verticalAlignment does nothing.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](Link goes here!)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
