### PR TITLE
feat: [KI 1055033] geocoordinates - disable cache - simulationBehavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Change simulation behavior to `default` on custom product-comparison queries
+
 ## [3.0.0] - 2022-04-26
 
 ### Added

--- a/store/blocks/deals.jsonc
+++ b/store/blocks/deals.jsonc
@@ -13,7 +13,7 @@
         "hideUnavailableItems": true,
         "maxItemsPerPage": 10,
         "skusFilter": "ALL",
-        "simulationBehavior": "skip"
+        "simulationBehavior": "default"
       }
     },
     "blocks": [

--- a/store/blocks/header/search-bar.jsonc
+++ b/store/blocks/header/search-bar.jsonc
@@ -12,7 +12,7 @@
       "product-summary.shelf#searchBar"
     ],
     "props": {
-      "simulationBehavior": "skip",
+      "simulationBehavior": "default",
       "maxSuggestedProducts": 6,
       "customBreakpoints": {
         "md": {
@@ -26,7 +26,7 @@
       "product-summary.shelf#searchBarMobile"
     ],
     "props": {
-      "simulationBehavior": "skip",
+      "simulationBehavior": "default",
       "maxSuggestedProducts": 6,
       "autocompleteWidth": 92
     }

--- a/store/blocks/popular.jsonc
+++ b/store/blocks/popular.jsonc
@@ -13,7 +13,7 @@
         "hideUnavailableItems": true,
         "maxItemsPerPage": 10,
         "skusFilter": "ALL",
-        "simulationBehavior": "skip"
+        "simulationBehavior": "default"
       }
     },
     "blocks": [

--- a/store/blocks/releases.jsonc
+++ b/store/blocks/releases.jsonc
@@ -12,7 +12,7 @@
         "hideUnavailableItems": true,
         "maxItemsPerPage": 10,
         "skusFilter": "ALL",
-        "simulationBehavior": "skip"
+        "simulationBehavior": "default"
       }
     },
     "blocks": [

--- a/store/blocks/search.jsonc
+++ b/store/blocks/search.jsonc
@@ -4,7 +4,7 @@
     "props": {
       "context": {
         "skusFilter": "ALL",
-        "simulationBehavior": "skip"
+        "simulationBehavior": "default"
       }
     }
   },
@@ -16,7 +16,7 @@
         "hideUnavailableItems": true,
         "maxItemsPerPage": 10,
         "skusFilter": "ALL",
-        "simulationBehavior": "skip"
+        "simulationBehavior": "default"
       }
     }
   },
@@ -25,7 +25,7 @@
     "props": {
       "context": {
         "skusFilter": "ALL",
-        "simulationBehavior": "skip",
+        "simulationBehavior": "default",
         "maxItemsPerPage": 20
       },
       "fullWidth": true
@@ -36,7 +36,7 @@
     "props": {
       "context": {
         "skusFilter": "ALL",
-        "simulationBehavior": "skip",
+        "simulationBehavior": "default",
         "maxItemsPerPage": 20
       },
       "fullWidth": true
@@ -47,7 +47,7 @@
     "props": {
       "context": {
         "skusFilter": "ALL",
-        "simulationBehavior": "skip",
+        "simulationBehavior": "default",
         "maxItemsPerPage": 20
       },
       "fullWidth": true

--- a/store/blocks/top-sales.jsonc
+++ b/store/blocks/top-sales.jsonc
@@ -12,7 +12,7 @@
         "hideUnavailableItems": true,
         "maxItemsPerPage": 10,
         "skusFilter": "ALL",
-        "simulationBehavior": "skip"
+        "simulationBehavior": "default"
       }
     },
     "blocks": [

--- a/store/blocks/trending.jsonc
+++ b/store/blocks/trending.jsonc
@@ -12,7 +12,7 @@
         "hideUnavailableItems": true,
         "maxItemsPerPage": 10,
         "skusFilter": "ALL",
-        "simulationBehavior": "skip"
+        "simulationBehavior": "default"
       }
     },
     "blocks": [


### PR DESCRIPTION
#### What problem is this solving?

The product appears with an unavailable status, different from the real status
<br class="Apple-interchange-newline">

<!--- What is the motivation and context for this change? -->

#### How to test it?

- Create a user linked to this org: https://b2bstore005.myvtex.com/admin/b2b-organizations/organizations/125129e4-5bd0-11ef-b37f-e4b50a4acd8d/#/users
- Search for the "test" product in the search to check if appears as available

[Workspace](https://developers.vtex.com/docs/apps/vtex.search-result)

#### Screenshots or example usage:

The property simulationBehavior was changed to "[default](url)"
(simulationBehavior: Defines whether the search data will be up-to-date (default) or fetched using the Cache (skip). You should only use the last option if you prefer faster queries than the most up-to-date prices or inventory.)

![Screenshot 2024-09-25 at 17 39 05](https://github.com/user-attachments/assets/871ff8e7-caf3-41bc-be3d-a748a3eeda45)

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

https://github.com/vtex-apps/storefront-permissions/pull/160
<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

[https://giphy.com/gifs/Friends-season-5-episode-111-the-one-where-everybody-finds-out-YnBntKOgnUSBkV7bQH](url)