### PR TITLE
Removing `b2b-warning-topbar-inactive-organization` block due to inco…

### DIFF
--- a/store/blocks/header/header.jsonc
+++ b/store/blocks/header/header.jsonc
@@ -22,7 +22,7 @@
     },
     "children": [
       "flex-layout.row#telemarketing",
-      "flex-layout.row#pendingOrgAlert",
+      //"flex-layout.row#pendingOrgAlert",
       "flex-layout.row#organization",
       "flex-layout.row#desktop",
       "flex-layout.row#headerStripe",


### PR DESCRIPTION
#### What problem is this solving?

Removing `b2b-warning-topbar-inactive-organization` block due to invalid logic

#### How to test it?

[Workspace](https://tkt1154349--b2bfabiolamolina.myvtex.com/)

#### Screenshots or example usage:

Before:
![image](https://github.com/user-attachments/assets/49b9cd03-2c40-4f17-b4bd-672c5225d05d)


After:
![image](https://github.com/user-attachments/assets/41272cff-3816-4aea-ae59-e98976082cd4)
